### PR TITLE
use scipy scalar minimize

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12",  "3.13"]
+        python-version: ["3.11", "3.12",  "3.13"]
         platform: [ubuntu-latest]  #, macos-latest, windows-latest]
 
     steps:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Tilt-axis angle optimization for tilt series using common lines.
 
 ## Overview
 
-torch-refine-tilt-axis-angle provides an implementation for finding the in plane rotation for a tilt-series that aligns the tilt axis with the y-axis. This is done by extracting lines from the 2D Fourier transform of the tilt-series images and minimizing the mean squared error between them, i.e. the common lines. It makes use of the pytorch LBFGS optimizer to find the minimum.
+torch-refine-tilt-axis-angle provides an implementation for finding the in plane rotation for a tilt-series that aligns the tilt axis with the y-axis. This is done by extracting lines from the 2D Fourier transform of the tilt-series images and minimizing the mean squared error between them, i.e. the common lines. It makes use of scipy's Brent's method (bounded) to find the minimum.
 
 ## Installation
 
@@ -37,8 +37,8 @@ initial_tilt_axis_angle = 50.0
 new_tilt_axis_angle = refine_tilt_axis_angle(
     tilt_series=tilt_series,
     tilt_axis_angle=initial_tilt_axis_angle,
-    # grid_points=1,  # optionally increase the spline grid points (default 1)
-    # return_single_angle=False,  # optionally write out an angle for each image 
+    search_range=10.0,  # search range around initial angle in degrees (default 10.0)
+    max_iter=20,  # maximum iterations for optimizer (default 20)
 )
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,8 +37,8 @@ classifiers = [
 dependencies = [
     "torch",
     "einops",
+    "scipy",
     "torch-fourier-slice",
-    "torch-cubic-spline-grids",
     "torch-affine-utils",
     "torch-grid-utils",
 ]

--- a/src/torch_refine_tilt_axis_angle/refine_tilt_axis_angle.py
+++ b/src/torch_refine_tilt_axis_angle/refine_tilt_axis_angle.py
@@ -14,7 +14,7 @@ def refine_tilt_axis_angle(
     tilt_series: torch.Tensor,
     tilt_axis_angle: float = 0.0,
     search_range: float = 10.0,
-    max_iter: int = 10,
+    max_iter: int = 20,
 ) -> float:
     """Refine the tilt axis angle for electron tomography data.
 

--- a/src/torch_refine_tilt_axis_angle/refine_tilt_axis_angle.py
+++ b/src/torch_refine_tilt_axis_angle/refine_tilt_axis_angle.py
@@ -2,26 +2,25 @@
 
 import einops
 import torch
+from scipy.optimize import minimize_scalar  # type: ignore[import-untyped]
 from torch_affine_utils.transforms_2d import R
 
 # teamtomo torch functionality
-from torch_cubic_spline_grids import CubicBSplineGrid1d
-from torch_fourier_slice import project_2d_to_1d
-from torch_grid_utils import circle
+from torch_fourier_slice import project_2d_to_1d  # type: ignore[import-untyped]
+from torch_grid_utils import circle  # type: ignore[import-untyped]
 
 
 def refine_tilt_axis_angle(
     tilt_series: torch.Tensor,
-    tilt_axis_angle: torch.Tensor | float = 0.0,
-    grid_points: int = 1,
-    iterations: int = 3,
-    return_single_angle: bool = True,
-) -> torch.Tensor:
+    tilt_axis_angle: float = 0.0,
+    search_range: float = 10.0,
+    max_iter: int = 10,
+) -> float:
     """Refine the tilt axis angle for electron tomography data.
 
-    Uses common line projections and LBFGS optimization to find the optimal
-    tilt axis angle(s) that minimize differences between projections across
-    the tilt series.
+    Uses common line projections and scipy's Brent's method (bounded) to find
+    the optimal tilt axis angle that minimizes differences between projections
+    across the tilt series.
 
     Parameters
     ----------
@@ -29,31 +28,25 @@ def refine_tilt_axis_angle(
         Tensor containing the tilt series images with shape [n_tilts, height, width].
     tilt_axis_angle : float, default=0.0
         Initial guess for the tilt axis angle in degrees.
-    grid_points : int, default=1
-        Number of control points for the cubic B-spline grid. When > 1, allows for
-        non-constant tilt axis angle across the tilt series.
-    iterations : int, default=3
-        Number of LBFGS optimization iterations to perform.
-    return_single_angle : bool, default=True
-        Return a single value for the tilt axis angle instead of a tensor
-        with one value per tilt.
+    search_range : float, default=10.0
+        Search range around the initial angle in degrees (±search_range).
+    max_iter : int, default=10
+        Maximum iterations for Brent's method optimizer.
 
     Returns
     -------
-    torch.Tensor or float
-        If grid_points=1: a single float with the optimized mean tilt axis angle.
-        If grid_points>1: a tensor of optimized tilt axis angles for each tilt.
+    float
+        The optimized tilt axis angle in degrees.
 
     Notes
     -----
     The function works by:
-    1. Applying a B-spline representation to model the tilt axis angle
-    2. Projecting images perpendicular to the tilt axis
-    3. Comparing these projections across different tilts
-    4. Minimizing differences between projections using LBFGS optimizer
+    1. Projecting images perpendicular to the tilt axis to extract common lines
+    2. Comparing these projections across different tilts
+    3. Minimizing differences between projections using Brent's method
 
-    Common line projections are normalized and weighted according to the
-    projected mask to emphasize regions of interest.
+    Common line projections are normalized and weighted according to a
+    projected spherical mask to emphasize regions of interest.
     """
     n_tilts, h, w = tilt_series.shape
     device = tilt_series.device
@@ -66,7 +59,7 @@ def refine_tilt_axis_angle(
         image_shape=(h, w),
         device=device,
     )
-    tilt_series = tilt_series * alignment_mask
+    masked_tilt_series = tilt_series * alignment_mask
 
     # generate a weighting for the common line ROI by projecting the mask
     mask_weights = project_2d_to_1d(
@@ -75,35 +68,22 @@ def refine_tilt_axis_angle(
     )
     mask_weights = mask_weights / mask_weights.max()  # normalise to 0 and 1
 
-    # optimize tilt axis angle
-    tilt_axis_grid = CubicBSplineGrid1d(resolution=grid_points, n_channels=1)
-    tilt_axis_grid.data = torch.tensor(
-        [
-            tilt_axis_angle,
-        ]
-        * grid_points,
-        dtype=torch.float32,
-        device=device,
-    )
-    tilt_axis_grid.to(device)
-    interpolation_points = torch.linspace(0, 1, n_tilts, device=device)
-
-    lbfgs = torch.optim.LBFGS(
-        tilt_axis_grid.parameters(),
-        line_search_fn="strong_wolfe",
-    )
-
-    def closure() -> torch.Tensor:
+    def objective(angle: float) -> float:
+        """Objective function: compute loss for given tilt axis angle."""
         # The common line is the projection perpendicular to the
         # tilt-axis, hence add 90 degrees to project along the x-axis
-        pred_tilt_axis_angles = tilt_axis_grid(interpolation_points) + 90.0
-        M = R(pred_tilt_axis_angles, yx=False)
+        angle_tensor = torch.tensor(
+            [angle + 90.0] * n_tilts,
+            dtype=torch.float32,
+            device=device,
+        )
+        M = R(angle_tensor, yx=False)
         M = M[:, :2, :2]  # we only need the rotation matrix
-        M = M.to(device)
 
         projections = torch.cat(
             [  # indexing with [[i]] does not drop the dimension
-                project_2d_to_1d(tilt_series[i], M[[i]]) for i in range(n_tilts)
+                project_2d_to_1d(masked_tilt_series[i], M[[i]])
+                for i in range(n_tilts)
             ]
         )
         projections = projections - einops.reduce(
@@ -111,20 +91,23 @@ def refine_tilt_axis_angle(
         )
         projections = projections / torch.std(projections, dim=(-1), keepdim=True)
         projections = projections * mask_weights  # weight the common lines
-        lbfgs.zero_grad()
+
         squared_differences = (
             projections - einops.rearrange(projections, "b d -> b 1 d")
         ) ** 2
         loss = einops.reduce(squared_differences, "b1 b2 d -> 1", reduction="sum")
-        loss.backward()
-        return loss
+        return float(loss.item())
 
-    for _ in range(iterations):
-        lbfgs.step(closure)
+    # Define search bounds
+    angle_min = tilt_axis_angle - search_range
+    angle_max = tilt_axis_angle + search_range
 
-    tilt_axis_angles = tilt_axis_grid(interpolation_points).detach()
+    # Run Brent's method optimization
+    result = minimize_scalar(
+        objective,
+        bounds=(angle_min, angle_max),
+        method="bounded",
+        options={"maxiter": max_iter},
+    )
 
-    if return_single_angle:
-        return torch.mean(tilt_axis_angles)
-    else:
-        return tilt_axis_angles
+    return float(result.x)

--- a/tests/test_torch_refine_tilt_axis_angle.py
+++ b/tests/test_torch_refine_tilt_axis_angle.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 import torch
@@ -19,7 +19,13 @@ def sample_data():
 
 def test_refine_tilt_axis_angle_default_parameters(sample_data):
     """Test refine_tilt_axis_angle with default parameters."""
-    with patch("torch.optim.LBFGS.step"):
+    mock_result = MagicMock()
+    mock_result.x = 0.0
+
+    with patch(
+        "torch_refine_tilt_axis_angle.refine_tilt_axis_angle.minimize_scalar",
+        return_value=mock_result,
+    ):
         # Setup
         tilt_series = sample_data["tilt_series"]
 
@@ -27,13 +33,19 @@ def test_refine_tilt_axis_angle_default_parameters(sample_data):
         result = refine_tilt_axis_angle(tilt_series=tilt_series)
 
         # Assertions
-        assert isinstance(result, torch.Tensor)
-        assert result.ndim == 0  # should be a single value
+        assert isinstance(result, float)
 
 
-def test_refine_tilt_axis_angle_with_single_grid_point(sample_data):
-    """Test refine_tilt_axis_angle with a single grid point."""
-    with patch("torch.optim.LBFGS.step"):
+def test_refine_tilt_axis_angle_with_custom_parameters(sample_data):
+    """Test refine_tilt_axis_angle with custom parameters."""
+    # Create a mock result object
+    mock_result = MagicMock()
+    mock_result.x = 42.5
+
+    with patch(
+        "torch_refine_tilt_axis_angle.refine_tilt_axis_angle.minimize_scalar",
+        return_value=mock_result,
+    ):
         # Setup
         tilt_series = sample_data["tilt_series"]
         initial_angle = 45.0
@@ -42,51 +54,63 @@ def test_refine_tilt_axis_angle_with_single_grid_point(sample_data):
         result = refine_tilt_axis_angle(
             tilt_series=tilt_series,
             tilt_axis_angle=initial_angle,
-            grid_points=1,
-            iterations=2,
+            search_range=15.0,
+            max_iter=20,
         )
 
         # Assertions
-        assert result.ndim == 0  # With grid_points=1, should return float
+        assert isinstance(result, float)
+        assert result == 42.5
 
 
-def test_refine_tilt_axis_angle_with_multiple_grid_points(sample_data):
-    """Test refine_tilt_axis_angle with multiple grid points."""
-    with patch("torch.optim.LBFGS.step"):
+def test_refine_tilt_axis_angle_bounds(sample_data):
+    """Test that minimize_scalar is called with correct bounds."""
+    mock_result = MagicMock()
+    mock_result.x = 5.0
+
+    with patch(
+        "torch_refine_tilt_axis_angle.refine_tilt_axis_angle.minimize_scalar",
+        return_value=mock_result,
+    ) as mock_minimize:
         # Setup
         tilt_series = sample_data["tilt_series"]
-        initial_angle = 45.0
+        initial_angle = 30.0
+        search_range = 10.0
 
         # Call the function
-        result = refine_tilt_axis_angle(
-            tilt_series=tilt_series,
-            tilt_axis_angle=initial_angle,
-            iterations=2,
-            return_single_angle=False,
-        )
-
-        # Assertions
-        assert isinstance(
-            result, torch.Tensor
-        )  # With grid_points>1, should return tensor
-        assert result.shape[0] == tilt_series.shape[0]  # One angle per tilt
-        assert not result.requires_grad  # Should be detached
-
-
-def test_refine_tilt_axis_angle_optimization_iterations(sample_data):
-    """Test that the number of optimization iterations are executed."""
-    # Setup
-    tilt_series = sample_data["tilt_series"]
-    initial_angle = 45.0
-
-    # Call the function with different iteration counts
-    with patch("torch.optim.LBFGS.step") as mock_step:
         refine_tilt_axis_angle(
             tilt_series=tilt_series,
             tilt_axis_angle=initial_angle,
-            grid_points=3,
-            iterations=5,
+            search_range=search_range,
         )
 
-        # Assert that step was called the correct number of times
-        assert mock_step.call_count == 5
+        # Assert minimize_scalar was called with correct bounds
+        mock_minimize.assert_called_once()
+        call_kwargs = mock_minimize.call_args[1]
+        assert call_kwargs["bounds"] == (20.0, 40.0)  # initial ± search_range
+        assert call_kwargs["method"] == "bounded"
+
+
+def test_refine_tilt_axis_angle_optimization_max_iter(sample_data):
+    """Test that max_iter parameter is passed to minimize_scalar."""
+    mock_result = MagicMock()
+    mock_result.x = 0.0
+
+    with patch(
+        "torch_refine_tilt_axis_angle.refine_tilt_axis_angle.minimize_scalar",
+        return_value=mock_result,
+    ) as mock_minimize:
+        # Setup
+        tilt_series = sample_data["tilt_series"]
+        max_iter = 15
+
+        # Call the function
+        refine_tilt_axis_angle(
+            tilt_series=tilt_series,
+            max_iter=max_iter,
+        )
+
+        # Assert minimize_scalar was called with correct max_iter
+        mock_minimize.assert_called_once()
+        call_kwargs = mock_minimize.call_args[1]
+        assert call_kwargs["options"]["maxiter"] == max_iter


### PR DESCRIPTION
@alisterburt I got inspired by your pretilt offset idea. I think this is a more robust optimization strategy. Just some results on a random tilt-series:

```
In [25]: refine_tilt_axis_angle(shifted[..., 18:-18].to('cuda'), -85, max_iter=20)
Out[25]: -92.39525013899616

In [26]: refine_tilt_axis_angle(shifted[..., 18:-18].to('cuda'), -95, max_iter=20)
Out[26]: -92.4031145602992
```

I think the bounds also make sense, because we generally assume the estimated tilt axis angle to be close to correct.